### PR TITLE
Add tool-output-mimicry to Bypass Security Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ IDA plugin which queries OpenAI's gpt-3.5-turbo language model to speed up rever
 * [Universal and Transferable Adversarial Attacks on Aligned Language Models](https://llm-attacks.org/)
 * [promptbench](https://github.com/microsoft/promptbench) - A robustness evaluation framework for large language models on adversarial prompts
 * [jailbreak_llms](https://github.com/verazuo/jailbreak_llms) - A dataset consists of 15,140 ChatGPT prompts from Reddit, Discord, websites, and open-source datasets (including 1,405 jailbreak prompts).
+* [tool-output-mimicry](https://github.com/314-ia/tool-output-mimicry) - Reference reproducer for the Tool Output Mimicry primitive: bypasses multi-layer agentic AI defenses by impersonating an upstream agent's task summary in a user-controlled field that a downstream agent reads. Validated end-to-end against the OWASP FinBot CTF; companion paper at doi.org/10.5281/zenodo.19794072.
 
 ### Bug Bounty
 


### PR DESCRIPTION
## Summary

Adds [`314-ia/tool-output-mimicry`](https://github.com/314-ia/tool-output-mimicry) under **Tools → Bypass Security Policy**.

## What it is

Reference reproducer for the *Tool Output Mimicry* primitive — a multi-agent attack that bypasses layered defenses by impersonating an upstream agent's task summary in a user-controlled field that a downstream agent reads. Companion paper:

> Brana, J. P. (2026). *Tool Output Mimicry: Bypassing Multi-Layer Agentic AI Defenses via Upstream-Agent Impersonation in User-Controlled Fields.* Zenodo. [doi:10.5281/zenodo.19794072](https://doi.org/10.5281/zenodo.19794072) (CC BY 4.0).

## Why this section

The section already lists prompt-injection bypass tools (`promptmap`), adversarial-attack research (`Universal and Transferable...`), and bypass datasets (`jailbreak_llms`). This entry is a focused *reproducer* for a specific multi-agent prompt-injection variant — the section's "Bypass Security Policy" theme is a direct fit. The paper sits alongside Greshake et al. *More than you've asked for...* (already listed in Cases > Academic) as the next refinement of indirect prompt injection.

## What ships

- Reference Python implementation of the primitive
- End-to-end FinBot CTF reproducer with `--dry-run` smoke path (zero credentials)
- 24 unit tests passing on Python 3.10–3.13 (CI matrix green)
- Verbatim live-capture transcript (re-validated 2026-04-27)

## Style compliance

- One line, `* [name](url) - description.` matching the section's existing format
- One suggestion per PR (per CONTRIBUTING.md)