### PR TITLE
Add Agent Threat Rules to Detecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ IATelligence is a Python script that will extract the IAT of a PE file and reque
 * [LLMFuzzer](https://github.com/mnns/LLMFuzzer) - LLMFuzzer is the first open-source fuzzing framework specifically designed for Large Language Models (LLMs), especially for their integrations in applications via LLM APIs.
 * [Vigil](https://github.com/deadbits/vigil-llm) - Prompt injection detection and LLM prompt security scanner
 * [AgentShield](https://github.com/elliotllliu/agent-shield) - Security scanner for AI agent skills, MCP servers, and plugins. 31 rules detect prompt injection (8 languages, 55+ patterns), data exfiltration, backdoors, tool poisoning, and cross-file attack chains. Includes MCP runtime proxy for real-time interception.
+* [Agent Threat Rules (ATR)](https://github.com/Agent-Threat-Rule/agent-threat-rules) - Open detection standard for AI agent threats (prompt injection, tool poisoning, MCP attacks, skill compromise) — Sigma/YARA-style YAML rules. 330 rules across 9 attack categories with full mapping to OWASP Agentic Top 10 (10/10), MITRE ATLAS (100/113), NIST AI RMF (100%), and SAFE-MCP (78/85). 97.1% recall on the garak probe set and 0% false-positive on 53,577 real-world MCP skills. Shipped in production at Cisco AI Defense and Microsoft agent-governance-toolkit. Apache-2.0.
 
 ### Preventing
 


### PR DESCRIPTION
Adding Agent Threat Rules (ATR) to the Detecting section, next to AgentShield. ATR is an open detection standard for AI agent threats — Sigma/YARA-style YAML rules for prompt injection, tool poisoning, MCP attacks, and skill compromise. It complements scanners already in this section (rebuff, Vigil, AgentShield) by providing the underlying rule library that detection tools can load.

The corpus is 330 rules across 9 attack categories, mapped to OWASP Agentic Top 10 (10/10), MITRE ATLAS (100/113), NIST AI RMF (100%), and SAFE-MCP (78/85). 97.1% recall on the garak probe set and 0% false-positive on 53,577 real-world MCP skills.

ATR is shipped in production at Cisco AI Defense (skill-scanner pack) and Microsoft agent-governance-toolkit (PolicyEvaluator examples).

Repo: https://github.com/Agent-Threat-Rule/agent-threat-rules
License: Apache-2.0

Diff is one line in the existing Detecting subsection, formatted to match neighboring entries.