### PR TITLE
Add Cybrium MCP Server to Tools → Audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Here is [A nice tool](https://github.com/cckuailong/SuperAdapters) to Finetune A
 * [AuthzAI](https://github.com/ngalongc/AuthzAI) - An automated tool to test and analyze API endpoints for potential permission model violations using OpenAI structured outputs.
 * [SinkFinder](https://github.com/Phelaine/SinkFinder) - Semi-automatic vulnerability mining tool for closed-source systems, static code analysis for jar/war/zip, adding LLM large model capability to verify path accessibility, LLM determines the trust score of the path based on the context code environment
 * [VulnHawk](https://github.com/momenbasel/vulnhawk) - LLM-powered SAST scanner that uses context-enriched analysis with Claude, GPT, and Ollama to detect vulnerabilities requiring business logic understanding such as missing authorization, IDOR, and inconsistent security controls
+* [Cybrium MCP Server](https://github.com/cybrium-ai/mcp-server) - MCP server exposing cyscan (SAST/SCA/secrets — 1,815 rules / 75+ languages) and cyradar (discover self-hosted Ollama/vLLM/TGI/Triton/LM Studio + inventory local AI tooling for AI BOM / AIBOM generation) to Claude, Cursor, Windsurf, Cline. AI agents auto-pick the right tool when developers ask about code security or shadow-AI audits. `npm install -g @cybrium-ai/mcp-server`.
 
 ### Reconnaissance
 


### PR DESCRIPTION
Adds [@cybrium-ai/mcp-server](https://github.com/cybrium-ai/mcp-server) at the end of the **Audit** subsection.

MCP server exposing Cybrium's CLI suite to Claude, Cursor, Windsurf, Cline:
- `scan` / `fix` etc. — cyscan (1,815 rules / 75+ languages)
- `web_scan` — cyweb
- `network_discover` — cyprobe
- `ai_discover` / `ai_local_scan` — **cyradar** (find self-hosted Ollama/vLLM/TGI/Triton/LM Studio + local AI tooling) — particularly relevant to this list since it powers AI BOM / AIBOM / shadow-AI audits.
- `email_security_scan` — cymail

`npm install -g @cybrium-ai/mcp-server` · Apache-2.0 · v0.3.0.