### PR TITLE
Add APort to GPT security prevention tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ IATelligence is a Python script that will extract the IAT of a PE file and reque
 
 ### Preventing
 
+* [APort](https://aport.io) - Agent identity verification and policy enforcement for LLM/GPT tool calls, adding pre-action authorization guardrails before agents execute sensitive actions.
+
 ### Social Engineering
 
 * [ChatGPT-Web-Setting-Funny-Abuse](https://github.com/Esonhugh/ChatGPT-Web-Setting-Funny-Abuse) - Play with ChatGPT-Web and found the HTML rendering in description settings.


### PR DESCRIPTION
## Summary
- Add APort under the Preventing section.
- Keep the entry to one link and a concise description per the contribution guidelines.

## Verification
- `git diff --check`
- Checked `https://aport.io` returns HTTP 200.

Related bounty: https://github.com/aporthq/aport-integrations/issues/19