### PR TITLE
Add AdversaryGraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ IDA plugin which queries OpenAI's gpt-3.5-turbo language model to speed up rever
 * [falco-gpt](https://github.com/Dentrax/falco-gpt) - AI-generated remediations for Falco audit events
 * [selefra](https://github.com/selefra/selefra) - an open-source policy-as-code software that provides analytics for multi-cloud and SaaS.
 * [openai-cti-summarizer](https://github.com/EC-DIGIT-CSIRC/openai-cti-summarizer) - openai-cti-summarizer is a tool for generating threat intelligence summary reports based on OpenAI's GPT-3.5 and GPT-4 API
+* [AdversaryGraph](https://github.com/anpa1200/adversarygraph) - AI-assisted CTI-to-detection workbench for ATT&CK/ATLAS mapping, IOC enrichment, TTP comparison, and analyst reporting; Malware Analysis mode is WIP.
 * [HOL Guard](https://github.com/hashgraph-online/hol-guard) - Local-first runtime security for AI coding agents. Intercepts shell commands, secret reads, and MCP changes before execution with configurable protection levels.
 
 ---


### PR DESCRIPTION
Adds AdversaryGraph to the Assessment tools section.

The entry focuses on AI-assisted CTI-to-detection workflows and explicitly notes that Malware Analysis mode is WIP, following the contribution guidance for WIP items.

Validation: git diff --check.