### PR TITLE
Add hego.red to Blogs

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ IDA plugin which queries OpenAI's gpt-3.5-turbo language model to speed up rever
 * [Model Confusion - Weaponizing ML models for red teams and bounty hunters](https://5stars217.github.io/2023-08-08-red-teaming-with-ml-models/)
 * [Using LLMs to reverse JavaScript variable name minification](https://thejunkland.com/blog/using-llms-to-reverse-javascript-minification)
 * [CircleGuardBench - A full-fledged benchmark for evaluating protection capabilities of AI models](https://huggingface.co/blog/whitecircle-ai/circleguardbench)
+* [hego.red - Practical AI/LLM Red Teaming Notes](https://hego.red/)
 
 ### Fun
 


### PR DESCRIPTION
Adds **hego.red**, a free single-page practical guide to AI/LLM red teaming: prompt injection, jailbreaks, indirect injection, RAG poisoning, agent and tool attacks, a full methodology mapped to the OWASP LLM Top 10 and MITRE ATLAS, plus worked labs. No ads, no tracking, no signup.

Added under **Blogs**. Thanks for maintaining this list.