### PR TITLE
Add fpverify: behavioral-fingerprint audit for LLM API model substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Here is [A nice tool](https://github.com/cckuailong/SuperAdapters) to Finetune A
 * [AuthzAI](https://github.com/ngalongc/AuthzAI) - An automated tool to test and analyze API endpoints for potential permission model violations using OpenAI structured outputs.
 * [SinkFinder](https://github.com/Phelaine/SinkFinder) - Semi-automatic vulnerability mining tool for closed-source systems, static code analysis for jar/war/zip, adding LLM large model capability to verify path accessibility, LLM determines the trust score of the path based on the context code environment
 * [VulnHawk](https://github.com/momenbasel/vulnhawk) - LLM-powered SAST scanner that uses context-enriched analysis with Claude, GPT, and Ollama to detect vulnerabilities requiring business logic understanding such as missing authorization, IDOR, and inconsistent security controls
+* [fpverify](https://github.com/Mohamed7415/fpverify) - Detects silent model substitution by API relays/resellers via behavioral fingerprints (LLMs can't answer "pick a random number" randomly); sequential anytime-valid test caps false-positive rate at 1%, blatant swaps caught in ~15 one-token queries
 
 ### Reconnaissance
 


### PR DESCRIPTION
Adds [fpverify](https://github.com/Mohamed7415/fpverify) to Tools > Audit.

**What it is**: an open-source (MIT) auditor that catches API relays/resellers silently swapping the flagship LLM you paid for with a cheaper one. It exploits the fact that LLMs cannot answer 'pick a random number' randomly - each model's bias pattern is a stable behavioral fingerprint (built on the 'One Token Is Enough' paper, arXiv:2607.10252).

**Why it's awesome**:
- Sequential anytime-valid test: false-accusation probability capped at alpha=0.01 at any stopping point; blatant swaps caught in ~15 one-token queries (~USD 0.002)
- July 2026 measurement of 9 frontier models x 11 fresh instances each (raw data committed, one-command reproduction): 99 fresh instances produced only 4 distinct 'random numbers'
- Ships a red-team simulator (9 adversary types), a community reference-fingerprint library, a local web console (keys never leave your machine), 46 statistical tests, CI on Ubuntu/Windows
- Honest limits documented: a 4-round red/blue co-evolution analysis shows exactly where detection breaks (low-rate random dilution)

Follows the entry format (single link, description on the same line, placed in the Audit section).