### PR TITLE
Add SourceryKit to Detecting

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ IATelligence is a Python script that will extract the IAT of a PE file and reque
 * [AgentShield](https://github.com/elliotllliu/agent-shield) - Security scanner for AI agent skills, MCP servers, and plugins. 31 rules detect prompt injection (8 languages, 55+ patterns), data exfiltration, backdoors, tool poisoning, and cross-file attack chains. Includes MCP runtime proxy for real-time interception.
 * [Agent Threat Rules (ATR)](https://github.com/Agent-Threat-Rule/agent-threat-rules) - Open detection standard for AI agent threats (prompt injection, tool poisoning, MCP attacks, skill compromise) — Sigma/YARA-style YAML rules. 330 rules across 9 attack categories with full mapping to OWASP Agentic Top 10 (10/10), MITRE ATLAS (100/113), NIST AI RMF (100%), and SAFE-MCP (78/85). 97.1% recall on the garak probe set and 0% false-positive on 53,577 real-world MCP skills. Shipped in production at Cisco AI Defense and Microsoft agent-governance-toolkit. Apache-2.0.
 * [Armorer Guard](https://github.com/ArmorerLabs/Armorer-Guard) - Local Rust scanner and MCP proxy for AI-agent prompt injection, credential leakage, exfiltration, and risky tool-call arguments before execution.
+* [SourceryKit](https://github.com/ProvablyAI/sourcerykit) - Python SDK that verifies an AI agent's outbound requests and MCP handoffs against a source of truth using zero-knowledge proofs, blocking any call whose claims do not check out or whose endpoint is not on the trusted allow-list, and logging every outbound call.
 
 ### Preventing
 


### PR DESCRIPTION
Hi, opened this to add SourceryKit to the Detecting section, next to Armorer Guard since they cover similar ground on agent tool calls.

SourceryKit is a Python SDK that verifies an AI agent's outbound requests and MCP handoffs against a source of truth using zero-knowledge proofs, so a call only goes out if the agent's claims check out. It allow-lists trusted endpoints and logs every outbound call. It is source-available with a hosted backend for the proof check.

https://github.com/ProvablyAI/sourcerykit

Thanks for taking a look.
