### PR TITLE
Added NuGuard to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ IDA plugin which queries OpenAI's gpt-3.5-turbo language model to speed up rever
 
 ### Standard
 
+- [NuGuard](https://github.com/NuGuardAI/nuguard) - Open-source CLI generating an AI-SBOM, red-teaming MCP/tool misuse, prompt injection, and data exfiltration in agentic AI apps, with static/runtime behavioral policy validation.
 * [modelscan](https://github.com/protectai/modelscan) - Protection against Model Serialization Attacks
 * [promptfoo](https://github.com/promptfoo/promptfoo) - LLM red teaming and evaluation framework. Includes modelaudit for scanning ML models for malicious code, backdoors, and serialization attacks. CI/CD integration
 * [ATT&CK for LLM Apps](https://atlas.mitre.org/)


### PR DESCRIPTION
Adds NuGuard (https://github.com/NuGuardAI/nuguard), an open-source
(Apache-2.0) CLI that:
- Generates an AI-SBOM (AIBOM) from a local codebase or Git repo
- Performs structural/supply-chain risk analysis
- Runs automated red-teaming for prompt injection, tool/MCP misuse, and
  data exfiltration
- Validates AI behavioral policy compliance (static + runtime)
- Exports findings as SARIF/JSON/Markdown with remediation suggestions

Installable via `pip install nuguard`. Fits this list's GPT Security section alongside similar tools.